### PR TITLE
Fix type address for Typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "browser": "dist/blockdom.iife.js",
   "module": "dist/blockdom.es.js",
-  "types": "dist/types/index.d.ts",
+  "types": "dist/index.d.ts",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
I fixed the address of `types` inside `package.json`

Correct address:
```"types": "dist/index.d.ts",```
![image](https://user-images.githubusercontent.com/8418700/133735787-86e0cb79-65ba-4d81-a9ee-62c6581d5428.png)

Wrong address (before PR):
```"types": "dist/types/index.d.ts",```
![image](https://user-images.githubusercontent.com/8418700/133735995-ea97184d-efeb-49cf-a99c-90fc191fce6a.png)

