### PR TITLE
fix: use correct index for subchilds in some cases

### DIFF
--- a/src/block_compiler.ts
+++ b/src/block_compiler.ts
@@ -300,7 +300,8 @@ function buildContext(
   toIdx?: number
 ): BlockCtx {
   if (!ctx) {
-    ctx = { collectors: [], locations: [], children: [], cbRefs: [], refN: tree.refN };
+    const children = new Array(tree.info.filter((v) => v.type === "child").length);
+    ctx = { collectors: [], locations: [], children, cbRefs: [], refN: tree.refN };
     fromIdx = 0;
     toIdx = tree.refN - 1;
   }
@@ -351,16 +352,16 @@ function updateCtx(ctx: BlockCtx, tree: IntermediateTree) {
       case "child":
         if (info.isOnlyChild) {
           // tree is the parentnode here
-          ctx.children.push({
+          ctx.children[info.idx] = {
             parentRefIdx: info.refIdx!,
             isOnlyChild: true,
-          });
+          };
         } else {
           // tree is the anchor text node
-          ctx.children.push({
+          ctx.children[info.idx] = {
             parentRefIdx: parentTree(tree)!.refIdx!,
             afterRefIdx: info.refIdx!,
-          });
+          };
         }
         break;
       case "attribute": {

--- a/tests/block.test.ts
+++ b/tests/block.test.ts
@@ -128,6 +128,15 @@ describe("sub blocks", () => {
     expect(fixture.innerHTML).toBe("<div><p>1</p><p>yip yip</p><p>2</p></div>");
   });
 
+  test("block with text, subblock and siblings", async () => {
+    let block1 = createBlock(`<div><p>before<block-child-0/>after</p><block-child-1/></div>`);
+
+    let tree = block1([], [text("water"), text("fire")]);
+
+    mount(tree, fixture);
+    expect(fixture.innerHTML).toBe("<div><p>beforewaterafter</p>fire</div>");
+  });
+
   test("block with conditional child", async () => {
     const block1 = createBlock("<div><p><block-child-0/></p></div>");
     const block2 = createBlock("<span>foo</span>");


### PR DESCRIPTION
To compile blocks, we traverse the content once to build a tree, then
traverse that tree later to build the final optimized block code. And
this is fine, except that until this commit, we kind of assumed that the
children would be encountered in the same order, which is not true.

So, before this commit, it was possible to have a situation where we
would have the children located at a wrong position. The fix is simple
then: just use the child index value instead of pushing into a list.