### PR TITLE
fix: `build:package` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "build": "rollup -c",
-    "build:package": "rm -rf dist && tsc",
+    "build:package": "rm -rf dist && npm run build && tsc --emitDeclarationOnly",
     "release": "standard-version",
     "test": "jest",
     "test:watch": "jest --watch",


### PR DESCRIPTION
Hi @ged-odoo Thanks for the awesome library!

I've been using it with Vite and encountered the following error:

```sh
✘ [ERROR] Failed to resolve entry for package "blockdom". The package may have incorrect main/module/exports specified in its package.json. [plugin vite:dep-scan]
```

I checked the dist folder and noticed that the `blockdom.iife.js` and `blockdom.es.js` files are missing, which could be causing Vite to fail during resolution. Therefore, I think that the `build:package` script should also run the `rollup -c`. To address this, I've included it in and let `tsc` only generate types.